### PR TITLE
fix: Integrate compose-code-editor with correct package structure

### DIFF
--- a/app/src/main/java/com/example/androcode/MainActivity.kt
+++ b/app/src/main/java/com/example/androcode/MainActivity.kt
@@ -140,10 +140,12 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.draw.drawBehind // <-- Add import
 import androidx.compose.ui.geometry.Rect // <-- Add import
 
-// --- Compose Code Editor Imports (Reverting to original) --- //
-import com.wakaztahir.codeeditor.prettify.PrettifyParser // Original import
-import com.wakaztahir.codeeditor.theme.CodeThemeType // Original import
-import com.wakaztahir.codeeditor.utils.parseCodeAsAnnotatedString // Original import
+// --- Compose Code Editor Imports --- //
+import com.wakaztahir.codeeditor.highlight.prettify.PrettifyParser
+import com.wakaztahir.codeeditor.highlight.theme.CodeTheme
+import com.wakaztahir.codeeditor.highlight.theme.DefaultTheme
+import com.wakaztahir.codeeditor.highlight.theme.MonokaiTheme
+import com.wakaztahir.codeeditor.highlight.utils.parseCodeAsAnnotatedString
 // --- End Compose Code Editor Imports --- //
 
 @AndroidEntryPoint
@@ -207,16 +209,16 @@ class MainActivity : ComponentActivity() {
                             actions = {
                                 // Helper function for save logic
                                 fun handleSaveClick() {
-                                    if (openedFileUri != null) {
-                                        // Existing file, just save
-                                        editorViewModel.saveFile()
-                                    } else {
-                                        // New file, trigger "Save As..."
-                                        // Suggest a default filename (e.g., "untitled.txt")
-                                        // We could make this smarter later based on language detection
-                                        val suggestedName = "untitled.txt"
-                                        createFileLauncher.launch(suggestedName)
-                                    }
+                                        if (openedFileUri != null) {
+                                            // Existing file, just save
+                                            editorViewModel.saveFile()
+                                        } else {
+                                            // New file, trigger "Save As..."
+                                            // Suggest a default filename (e.g., "untitled.txt")
+                                            // We could make this smarter later based on language detection
+                                            val suggestedName = "untitled.txt"
+                                            createFileLauncher.launch(suggestedName)
+                                        }
                                 }
 
                                 // Save Button
@@ -305,15 +307,13 @@ fun EditorView(
     // --- Compose Code Editor Setup --- //
     val parser = remember { PrettifyParser() }
     // TODO: Make theme configurable later via Settings
-    var themeState by remember { mutableStateOf(CodeThemeType.Monokai) }
-    val theme = remember(themeState) { themeState.theme() }
+    val theme = remember { MonokaiTheme() } // Use Monokai theme
     // --- End Setup --- //
 
     // Define editor text style (might be partially overridden by library theme)
     val editorTextStyle = TextStyle(
         fontFamily = FontFamily.Monospace,
         fontSize = 14.sp,
-        // color = MaterialTheme.colorScheme.onSurface // Color might come from theme
     )
 
     Column(modifier = modifier) {
@@ -332,7 +332,7 @@ fun EditorView(
         } else {
             // --- Use OutlinedTextField with library's parser --- //
             OutlinedTextField(
-                value = textState, // Use the TextFieldValue from ViewModel
+                value = textState, 
                 onValueChange = {
                     // Update ViewModel with new TextFieldValue
                     // Parsing happens here to update the AnnotatedString within TextFieldValue
@@ -350,13 +350,9 @@ fun EditorView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .padding(horizontal = 8.dp, vertical = 4.dp), // Add some padding
+                    .padding(horizontal = 8.dp, vertical = 4.dp),
                 textStyle = editorTextStyle,
                 keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.None),
-                // REMOVED: onTextLayout, interactionSource (default is fine),
-                // REMOVED: visualTransformation (folding)
-                // REMOVED: decorationBox (gutter, drawing)
-                // REMOVED: cursorBrush (use default or theme's)
             )
         }
 

--- a/app/src/main/java/com/example/androcode/viewmodels/EditorViewModel.kt
+++ b/app/src/main/java/com/example/androcode/viewmodels/EditorViewModel.kt
@@ -23,7 +23,7 @@ import java.util.ArrayDeque
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.Job
 import androidx.compose.ui.text.AnnotatedString
-import com.wakaztahir.codeeditor.model.CodeLang
+import com.wakaztahir.codeeditor.highlight.model.CodeLang
 
 @HiltViewModel
 class EditorViewModel @Inject constructor(
@@ -66,7 +66,7 @@ class EditorViewModel @Inject constructor(
     val textFieldValue: StateFlow<TextFieldValue> = _textFieldValue.asStateFlow()
 
     // --- DETECTED LANGUAGE STATE --- //
-    private val _detectedLanguage = MutableStateFlow<CodeLang>(CodeLang.Default)
+    private val _detectedLanguage = MutableStateFlow<CodeLang>(CodeLang.SQL) // Using SQL as default since it has highlighting for most syntax
     val detectedLanguage: StateFlow<CodeLang> = _detectedLanguage.asStateFlow()
     // --- END DETECTED LANGUAGE STATE --- //
 
@@ -140,7 +140,7 @@ class EditorViewModel @Inject constructor(
                 _isModified.value = false
 
                 // Detect language and update state
-                detectLanguage(uri) // Just detect language
+                detectLanguage(uri)
 
                 // Initial TextFieldValue needs to be set AFTER language detection
                 // The UI will now be responsible for creating the initial AnnotatedString
@@ -159,7 +159,7 @@ class EditorViewModel @Inject constructor(
                  _loadedFileContent.value = null
                  _currentFileContent.value = null
                  _textFieldValue.value = TextFieldValue("")
-                 _detectedLanguage.value = CodeLang.Default
+                 _detectedLanguage.value = CodeLang.SQL
                  _isModified.value = false
                  _foldableRegions.value = emptyMap()
                  _foldedLines.value = emptySet()
@@ -194,9 +194,27 @@ class EditorViewModel @Inject constructor(
      */
     private fun detectLanguage(uri: Uri?) {
         val extension = uri?.lastPathSegment?.substringAfterLast('.', "")
-        _detectedLanguage.value = CodeLang.values().find { lang ->
-            lang.extensions.any { ext -> ext.equals(extension, ignoreCase = true) }
-        } ?: CodeLang.Default // Default if no match found
+        _detectedLanguage.value = when (extension?.lowercase()) {
+            "kt", "java" -> CodeLang.Java
+            "js" -> CodeLang.JavaScript
+            "py" -> CodeLang.Python
+            "css" -> CodeLang.CSS
+            "html", "xml" -> CodeLang.XML
+            "json" -> CodeLang.JSON
+            "md" -> CodeLang.Markdown
+            "c" -> CodeLang.C
+            "cpp", "cc" -> CodeLang.CPP
+            "cs" -> CodeLang.CSharp
+            "rb" -> CodeLang.Ruby
+            "go" -> CodeLang.Go
+            "rs" -> CodeLang.Rust
+            "sql" -> CodeLang.SQL
+            "sh" -> CodeLang.Bash
+            "dart" -> CodeLang.Dart
+            "scala" -> CodeLang.Scala
+            "yml", "yaml" -> CodeLang.YAML
+            else -> CodeLang.SQL // SQL as fallback since it handles general syntax well
+        }
         println("Detected language: ${_detectedLanguage.value} for extension: $extension")
     }
 


### PR DESCRIPTION
- Resolved import errors for compose-code-editor v2.0.3.

- Identified correct package structure (com.wakaztahir.codeeditor.highlight.*).

- Used MonokaiTheme instead of abstract CodeTheme.

- Restored syntax highlighting and language detection functionality.